### PR TITLE
Formula show: BCoV ddPCR error in template volume correction updated

### DIFF
--- a/calculations_multiple_runs.R
+++ b/calculations_multiple_runs.R
@@ -5,12 +5,10 @@ source('./inputs_for_analysis.R') # Source the file with user inputs
 # Parameters ----------------------------------------------------------------------
 
 # sheets to read from qPCR data dump excel file
-read_these_sheets <- c( 'dd.WW46_Bellaire daily part1-N1N2',
-                        'dd.WW56_Bellaire daily part2, Zachs old_N1N2',
-                        'WW83_Bellaire daily part2, Zach old samples repeat_BCoV_Std62',
-                        'WW87_Bellaire daily samples-1_BCoV_Std66')
+read_these_sheets <- c( 'WW84_ 1014 manhole BCoV_Std63',
+                        'dd.WW59_1014 Manhole_N1N2')
 
-title_name <- 'Bellaire daily and others'
+title_name <- '1014 manhole, Rice'
 
 # Biobot_id sheet
 bb_sheets <- c('Week 27 (10/12)')
@@ -19,7 +17,7 @@ bb_sheets <- c('Week 27 (10/12)')
 extra_categories = 'Std|Control|e811|Acetone' # for excluding this category from a plot, make the switch (exclude_sample = TRUE)
 special_samples = 'HCJ|SOH|ODM|AO' # putting special samples in a separate sheet
 
-regular_WWTP_run_output <- FALSE # make TRUE of you want to output the WWTP only data and special samples sheets 
+regular_WWTP_run_output <- TRUE # make TRUE of you want to output the WWTP only data and special samples sheets 
       # (make FALSE for controls, testing etc. where only "complete data" sheet is output)
 
 # rarely changed parameters

--- a/calculations_multiple_runs.R
+++ b/calculations_multiple_runs.R
@@ -15,7 +15,7 @@ title_name <- '1026 Rice'
 bb_sheets <- c('Week 29 (10/26)')
 
 # Extra categories for plotting separately (separate by | like this 'Vaccine|Troubleshooting')
-# extra_categories = 'Std|Control|e811|Acetone' # Depreciated: for excluding this category from a plot, make the switch (exclude_sample = TRUE)
+extra_categories = 'Std|Control|e811|Acetone' # Depreciated: for excluding this category from a plot, make the switch (exclude_sample = TRUE)
 manhole_samples = 'HCJ|SOH|ODM|AO' # putting manhole samples in a separate sheet
 
 regular_WWTP_run_output <- TRUE # make TRUE of you want to output the WWTP only data and manhole samples sheets 

--- a/calculations_multiple_runs.R
+++ b/calculations_multiple_runs.R
@@ -16,7 +16,8 @@ bb_sheets <- c('Week 29 (10/26)')
 
 # Extra categories for plotting separately (separate by | like this 'Vaccine|Troubleshooting')
 extra_categories = 'Std|Control|e811|Acetone' # Depreciated: for excluding this category from a plot, make the switch (exclude_sample = TRUE)
-manhole_samples = 'HCJ|SOH|ODM|AO' # putting manhole samples in a separate sheet
+manhole_samples = 'HCJ|SOH|ODM|AO|PM|MCHR|AW' # putting manhole samples in a separate sheet 
+# ideally put all manhole names into a sheet and read it when we have more
 
 regular_WWTP_run_output <- TRUE # make TRUE of you want to output the WWTP only data and manhole samples sheets 
       # (make FALSE for controls, testing etc. where only "complete data" sheet is output)

--- a/calculations_multiple_runs.R
+++ b/calculations_multiple_runs.R
@@ -5,13 +5,14 @@ source('./inputs_for_analysis.R') # Source the file with user inputs
 # Parameters ----------------------------------------------------------------------
 
 # sheets to read from qPCR data dump excel file
-read_these_sheets <- c( 'WW84_ 1014 manhole BCoV_Std63',
-                        'dd.WW59_1014 Manhole_N1N2')
+read_these_sheets <- c( 'dd.WW65_1019_N1N2',
+                        'dd.WW64_1019_BCoV',
+                        'dd.WW66_1019_Manhole_N1N2_BCoV')
 
-title_name <- '1014 manhole, Rice'
+title_name <- '1019 Rice'
 
 # Biobot_id sheet
-bb_sheets <- c('Week 27 (10/12)')
+bb_sheets <- c('Week 28 (10/19)')
 
 # Extra categories for plotting separately (separate by | like this 'Vaccine|Troubleshooting')
 extra_categories = 'Std|Control|e811|Acetone' # for excluding this category from a plot, make the switch (exclude_sample = TRUE)

--- a/calculations_multiple_runs.R
+++ b/calculations_multiple_runs.R
@@ -16,7 +16,7 @@ bb_sheets <- c('Week 28 (10/19)')
 
 # Extra categories for plotting separately (separate by | like this 'Vaccine|Troubleshooting')
 extra_categories = 'Std|Control|e811|Acetone' # for excluding this category from a plot, make the switch (exclude_sample = TRUE)
-special_samples = 'HCJ|SOH|ODM|AO' # putting special samples in a separate sheet
+manhole_samples = 'HCJ|SOH|ODM|AO' # putting special samples in a separate sheet
 
 regular_WWTP_run_output <- TRUE # make TRUE of you want to output the WWTP only data and special samples sheets 
       # (make FALSE for controls, testing etc. where only "complete data" sheet is output)
@@ -276,12 +276,12 @@ if(regular_WWTP_run_output)
     write_csv(present_only_WW, path = str_c('excel files/Weekly data to HHD/', title_name, '.csv'), na = '') # output csv file
   }
   
-  present_special_samples <- present_WW_data %>% filter(str_detect(Facility, special_samples))
+  present_manhole_samples <- present_WW_data %>% filter(str_detect(Facility, manhole_samples))
   
   # Write data if not empty
-  if(present_special_samples %>% plyr::empty() %>% !.){
-    check_ok_and_write(present_special_samples, sheeturls$wwtp_only_data, str_c(title_name, ' special samples')) # save results to a google sheet, ask for overwrite
-    write_csv(present_special_samples, path = str_c('excel files/Weekly data to HHD/', title_name, ' manhole samples.csv'), na = '') # output CSV file
+  if(present_manhole_samples %>% plyr::empty() %>% !.){
+    check_ok_and_write(present_manhole_samples, sheeturls$wwtp_only_data, str_c(title_name, ' special samples')) # save results to a google sheet, ask for overwrite
+    write_csv(present_manhole_samples, path = str_c('excel files/Weekly data to HHD/', title_name, ' manhole samples.csv'), na = '') # output CSV file
   }
 }
 

--- a/calculations_multiple_runs.R
+++ b/calculations_multiple_runs.R
@@ -5,20 +5,20 @@ source('./inputs_for_analysis.R') # Source the file with user inputs
 # Parameters ----------------------------------------------------------------------
 
 # sheets to read from qPCR data dump excel file
-read_these_sheets <- c( 'dd.WW65_1019_N1N2',
-                        'dd.WW64_1019_BCoV',
-                        'dd.WW66_1019_Manhole_N1N2_BCoV')
+read_these_sheets <- c( 'dd.WW68_1026_N1N2',
+                        'dd.WW69_1026_BCoV')
+                        # 'dd.WW66_1019_Manhole_N1N2_BCoV')
 
-title_name <- '1019 Rice'
+title_name <- '1026 Rice'
 
 # Biobot_id sheet
-bb_sheets <- c('Week 28 (10/19)')
+bb_sheets <- c('Week 29 (10/26)')
 
 # Extra categories for plotting separately (separate by | like this 'Vaccine|Troubleshooting')
-extra_categories = 'Std|Control|e811|Acetone' # for excluding this category from a plot, make the switch (exclude_sample = TRUE)
-manhole_samples = 'HCJ|SOH|ODM|AO' # putting special samples in a separate sheet
+# extra_categories = 'Std|Control|e811|Acetone' # Depreciated: for excluding this category from a plot, make the switch (exclude_sample = TRUE)
+manhole_samples = 'HCJ|SOH|ODM|AO' # putting manhole samples in a separate sheet
 
-regular_WWTP_run_output <- TRUE # make TRUE of you want to output the WWTP only data and special samples sheets 
+regular_WWTP_run_output <- TRUE # make TRUE of you want to output the WWTP only data and manhole samples sheets 
       # (make FALSE for controls, testing etc. where only "complete data" sheet is output)
 
 # rarely changed parameters
@@ -280,7 +280,7 @@ if(regular_WWTP_run_output)
   
   # Write data if not empty
   if(present_manhole_samples %>% plyr::empty() %>% !.){
-    check_ok_and_write(present_manhole_samples, sheeturls$wwtp_only_data, str_c(title_name, ' special samples')) # save results to a google sheet, ask for overwrite
+    check_ok_and_write(present_manhole_samples, sheeturls$wwtp_only_data, str_c(title_name, ' manhole samples')) # save results to a google sheet, ask for overwrite
     write_csv(present_manhole_samples, path = str_c('excel files/Weekly data to HHD/', title_name, ' manhole samples.csv'), na = '') # output CSV file
   }
 }

--- a/calculations_multiple_runs.R
+++ b/calculations_multiple_runs.R
@@ -5,14 +5,14 @@ source('./inputs_for_analysis.R') # Source the file with user inputs
 # Parameters ----------------------------------------------------------------------
 
 # sheets to read from qPCR data dump excel file
-read_these_sheets <- c( 'dd.WW64_1019_BCoV',
-                        'dd.WW65_1019_N1N2',
-                        'dd.WW66_1019_Manhole_N1N2_BCoV')
+read_these_sheets <- c( 'dd.WW68_1026_N1N2',
+                        'dd.WW69_1026_BCoV',
+                        'dd.WW70_1027 Manhole_others_N1N2_BCoV')
 
-title_name <- '1019 Rice'
+title_name <- '1026 Rice'
 
 # Biobot_id sheet
-bb_sheets <- c('Week 28 (10/19)')
+bb_sheets <- c('Week 29 (10/26)')
 
 # Extra categories for plotting separately (separate by | like this 'Vaccine|Troubleshooting')
 extra_categories = 'Std|Control|e811|Acetone' # Depreciated: for excluding this category from a plot, make the switch (exclude_sample = TRUE)

--- a/calculations_multiple_runs.R
+++ b/calculations_multiple_runs.R
@@ -5,14 +5,14 @@ source('./inputs_for_analysis.R') # Source the file with user inputs
 # Parameters ----------------------------------------------------------------------
 
 # sheets to read from qPCR data dump excel file
-read_these_sheets <- c( 'dd.WW68_1026_N1N2',
-                        'dd.WW69_1026_BCoV')
-                        # 'dd.WW66_1019_Manhole_N1N2_BCoV')
+read_these_sheets <- c( 'dd.WW64_1019_BCoV',
+                        'dd.WW65_1019_N1N2',
+                        'dd.WW66_1019_Manhole_N1N2_BCoV')
 
-title_name <- '1026 Rice'
+title_name <- '1019 Rice'
 
 # Biobot_id sheet
-bb_sheets <- c('Week 29 (10/26)')
+bb_sheets <- c('Week 28 (10/19)')
 
 # Extra categories for plotting separately (separate by | like this 'Vaccine|Troubleshooting')
 extra_categories = 'Std|Control|e811|Acetone' # Depreciated: for excluding this category from a plot, make the switch (exclude_sample = TRUE)

--- a/general_functions.R
+++ b/general_functions.R
@@ -298,7 +298,7 @@ plottm1 <- function(results_relevant)
 
 
 # Plotting mean, sd and individual replicates jitter
-plot_mean_sd_jitter <- function(.data_list = long_processed_minimal, long_format = TRUE, measure_var = 'Copy #', sample_var = '.*', exclude_sample = F, WWTP_var = '.*', exclude_WWTP = F, target_filter = '.*', colour_var = Target, x_var = assay_variable, y_var = `Copy #`, ascending_order = FALSE, facet_var = `Sample_name`, title_text = title_name, ylabel = 'Genome copies/ul RNA', xlabel = plot_assay_variable, facet_style = 'grid')
+plot_mean_sd_jitter <- function(.data_list = long_processed_minimal, long_format = TRUE, measure_var = 'Copy #', sample_var = '.*', exclude_sample = F, WWTP_var = wwtp_manhole_names, exclude_WWTP = F, target_filter = '.*', colour_var = Target, x_var = assay_variable, y_var = `Copy #`, ascending_order = FALSE, facet_var = `Sample_name`, title_text = title_name, ylabel = 'Genome copies/ul RNA', xlabel = plot_assay_variable, facet_style = 'grid')
 { # Convenient handle for repetitive plotting in the same format; Specify data format: long vs wide (specify in long_format = TRUE or FALSE)
   
   .dat_filtered <- .data_list %>% map( ~ filter(.x, 

--- a/general_functions.R
+++ b/general_functions.R
@@ -298,12 +298,14 @@ plottm1 <- function(results_relevant)
 
 
 # Plotting mean, sd and individual replicates jitter
-plot_mean_sd_jitter <- function(.data_list = long_processed_minimal, long_format = TRUE, measure_var = 'Copy #', sample_var = '.*', exclude_sample = F, target_filter = '.*', colour_var = Target, x_var = assay_variable, y_var = `Copy #`, ascending_order = FALSE, facet_var = `Sample_name`, title_text = title_name, ylabel = 'Genome copies/ul RNA', xlabel = plot_assay_variable, facet_style = 'grid')
+plot_mean_sd_jitter <- function(.data_list = long_processed_minimal, long_format = TRUE, measure_var = 'Copy #', sample_var = '.*', exclude_sample = F, WWTP_var = '.*', exclude_WWTP = F, target_filter = '.*', colour_var = Target, x_var = assay_variable, y_var = `Copy #`, ascending_order = FALSE, facet_var = `Sample_name`, title_text = title_name, ylabel = 'Genome copies/ul RNA', xlabel = plot_assay_variable, facet_style = 'grid')
 { # Convenient handle for repetitive plotting in the same format; Specify data format: long vs wide (specify in long_format = TRUE or FALSE)
   
-  .dat_filtered <- .data_list %>% map( filter, 
-                                  str_detect(`Sample_name`, sample_var, negate = exclude_sample), 
-                                  str_detect(Target, target_filter))
+  .dat_filtered <- .data_list %>% map( ~ filter(.x, 
+                                                if('Sample_name' %in% colnames(.x)) str_detect(`Sample_name`, sample_var, negate = exclude_sample) else TRUE, 
+                                                if('WWTP' %in% colnames(.x)) str_detect(WWTP, WWTP_var, negate = exclude_WWTP) else TRUE, 
+                                                str_detect(Target, target_filter))
+  )
   
   # filtering data to be plotted by user inputs
   if(long_format) # use long format if not plotting Copy #s - ex. Recovery, % recovery etc.

--- a/make_html_plots.Rmd
+++ b/make_html_plots.Rmd
@@ -51,7 +51,7 @@ wwtp_manhole_names <- all_WWTP_names %>% str_c(collapse = '|') %>% str_c(manhole
 
 ```{r copiesrna}
 
-  concWW_plot <- plot_mean_sd_jitter(sample_var = extra_categories, exclude_sample = T, x_var = WWTP, ylabel = 'Genome copies/ul RNA') 
+  concWW_plot <- plot_mean_sd_jitter(x_var = WWTP, ylabel = 'Genome copies/ul RNA') 
   
   concWW_plot %>% format_logscale_y() %>% print()
   
@@ -65,7 +65,7 @@ filled circles : Copies of surrogate virus recovered
 
 ```{r summarizing_plot}
 
-plot_mean_sd_jitter(measure_var = 'Recovered', sample_var = str_c(extra_categories), exclude_sample = T, target_filter = 'BCoV|BRSV', x_var = WWTP, ylabel = 'Genome copies/l Wastewater') %>%  format_logscale_y() %>% print()
+plot_mean_sd_jitter(measure_var = 'Recovered', target_filter = 'BCoV|BRSV', x_var = WWTP, ylabel = 'Genome copies/l Wastewater') %>%  format_logscale_y() %>% print()
 
 ```
 
@@ -74,7 +74,7 @@ plot_mean_sd_jitter(measure_var = 'Recovered', sample_var = str_c(extra_categori
 ```{r percentreco}
 
 
-  percentreco_plt <- plot_mean_sd_jitter(measure_var = 'Recovery fraction', sample_var = str_c(extra_categories, '|Vaccine'), exclude_sample = T, target_filter = 'BCoV|BRSV', x_var = WWTP, ylabel = 'Percentage recovery of surrogate virus') 
+  percentreco_plt <- plot_mean_sd_jitter(measure_var = 'Recovery fraction', target_filter = 'BCoV|BRSV', x_var = WWTP, ylabel = 'Percentage recovery of surrogate virus') 
   
  percentreco_plt %>% print()
 
@@ -91,11 +91,11 @@ plot_mean_sd_jitter(measure_var = 'Recovered', sample_var = str_c(extra_categori
 extra_samples_to_plot <- str_c(extra_categories, '|Vaccine|NTC') %>% str_remove('\\|Std|Std\\|')
 
 # N1/N2 and BCoV plots : Copies/ul RNA
-plot_mean_sd_jitter(sample_var = extra_samples_to_plot, exclude_sample = F, x_var = WWTP) %>% format_logscale_y() %>% print()
+plot_mean_sd_jitter(WWTP_var = wwtp_manhole_names, exclude_WWTP = T, x_var = WWTP) %>% format_logscale_y() %>% print()
 
 
 # Copies/l WW: N1/N2 and BCoV plots
-plot_mean_sd_jitter(measure_var = 'Recovered', sample_var = extra_samples_to_plot, x_var = WWTP, ylabel = 'Genome copies/l Wastewater') %>% 
+plot_mean_sd_jitter(measure_var = 'Recovered', WWTP_var = wwtp_manhole_names, exclude_WWTP = T, x_var = WWTP, ylabel = 'Genome copies/l Wastewater') %>% 
   format_logscale_y() %>% print()
 
 # # recovered vs spiked in plot for extra samples
@@ -103,7 +103,7 @@ plot_mean_sd_jitter(measure_var = 'Recovered', sample_var = extra_samples_to_plo
 #   format_logscale_y() %>% print()
 
 # % plot for extra samples
-plot_mean_sd_jitter(measure_var = 'Recovery fraction', sample_var = extra_samples_to_plot, target_filter = 'BCoV|BRSV', x_var = WWTP, ylabel = 'Percentage recovery of surrogate virus') %>% print()
+plot_mean_sd_jitter(measure_var = 'Recovery fraction', WWTP_var = wwtp_manhole_names, exclude_WWTP = T, target_filter = 'BCoV|BRSV', x_var = WWTP, ylabel = 'Percentage recovery of surrogate virus') %>% print()
 
 ```
 
@@ -145,7 +145,7 @@ plot_scatter(processed_quant_data, x_var = N1_multiplex, y_var = N2_multiplex) %
 
 ```{r n1n2streamlined}
 
-ordered_plt1 <- plot_mean_sd_jitter(measure_var = 'Recovered', sample_var = str_c(extra_categories, '|NTC|Vaccine'), exclude_sample = T, x_var = WWTP, ascending_order = T, ylabel = 'Genome copies/l Wastewater')
+ordered_plt1 <- plot_mean_sd_jitter(measure_var = 'Recovered', x_var = WWTP, ascending_order = T, ylabel = 'Genome copies/l Wastewater')
 
 ordered_plt1 %>% print()
 ordered_plt1 %>% format_logscale_y() %>% print()
@@ -156,7 +156,7 @@ ordered_plt1 %>% format_logscale_y() %>% print()
 
 ```{r orderedrna}
 
-ordered_plt1 <- plot_mean_sd_jitter(sample_var = str_c(extra_categories, '|NTC|Vaccine'), exclude_sample = T, x_var = WWTP, ascending_order = T, ylabel = 'Genome copies/ul RNA')
+ordered_plt1 <- plot_mean_sd_jitter(x_var = WWTP, ascending_order = T, ylabel = 'Genome copies/ul RNA')
 
 ordered_plt1 %>% print()
 ordered_plt1 %>% format_logscale_y() %>% print()
@@ -167,7 +167,7 @@ ordered_plt1 %>% format_logscale_y() %>% print()
 
 ```{r percentRecoverystreamlined}
 
-  recostr_plot <- plot_mean_sd_jitter(measure_var = 'Recovery fraction', sample_var = str_c(extra_categories,'|NTC|Vaccine'), exclude_sample = T, x_var = WWTP, ascending_order = T, ylabel = 'Percentage recovery of surrogate')
+  recostr_plot <- plot_mean_sd_jitter(measure_var = 'Recovery fraction', x_var = WWTP, ascending_order = T, ylabel = 'Percentage recovery of surrogate')
   
   recostr_plot %>% print()
 

--- a/make_html_plots.Rmd
+++ b/make_html_plots.Rmd
@@ -24,6 +24,9 @@ Quantifying CoV2-N1,N2 (multiplexed) and BCoV surrogate spiked into wastewater s
 
 ```{r scripts, fig.width = 12}
 
+# Make a string to filter out all regular WWTP and manhole samples to plot separately
+wwtp_manhole_names <- all_WWTP_names %>% str_c(collapse = '|') %>% str_c(manhole_samples, sep = '|')
+
 # plot individual biological replicates (for quality control)
 # map2(list_rawqpcr, read_these_sheets, ~(plot_biological_replicates(.x, title_text = .y)))
 
@@ -37,7 +40,7 @@ Quantifying CoV2-N1,N2 (multiplexed) and BCoV surrogate spiked into wastewater s
 ```{r all_plot}
 # all the plotting functions plot data: "long_processed_minimal" by default
 
-  concWW_plot <- plot_mean_sd_jitter(measure_var = 'Recovered', sample_var = extra_categories, exclude_sample = T, x_var = WWTP, ylabel = 'Genome copies/l Wastewater') 
+  concWW_plot <- plot_mean_sd_jitter(measure_var = 'Recovered', WWTP_var = wwtp_manhole_names, x_var = WWTP, ylabel = 'Genome copies/l Wastewater') 
   
   concWW_plot %>% format_logscale_y() %>% print()
   

--- a/make_html_plots.Rmd
+++ b/make_html_plots.Rmd
@@ -124,7 +124,10 @@ plot_scatter(processed_quant_data) %>% print()
 
 ```{r n1n2avg}
 
-plot_scatter(processed_quant_data, x_var = log10(N1_multiplex), y_var = log10(N2_multiplex)) %>% print()
+plot_scatter(processed_quant_data, x_var = N1_multiplex, y_var = N2_multiplex) %>% 
+  format_logscale_x() %>% 
+  format_logscale_y() %>% 
+  print()
 
 ```
 

--- a/processing_functions.R
+++ b/processing_functions.R
@@ -332,7 +332,7 @@ process_ddpcr <- function(flnm = flnm.here, baylor_wells = 'none', adhoc_dilutio
   
   
   # Saving vaccine data into Vaccines sheet in data dump: For easy book keeping
-  vaccine_data <- polished_results %>% filter(str_detect(Sample_name, 'Vaccine')) %>%
+  vaccine_data <- polished_results %>% filter(str_detect(Sample_name, 'Vaccine') & !str_detect(Target, 'N._multiplex')) %>%
     mutate('Prepared on' = '',
            Week = str_extract(flnm, '[:digit:]{3,4}') %>% unlist() %>% str_c(collapse = ', '),
            Vaccine_ID = assay_variable, 

--- a/processing_functions.R
+++ b/processing_functions.R
@@ -256,13 +256,10 @@ process_qpcr <- function(flnm = flnm.here, std_override = NULL, baylor_wells = '
 process_ddpcr <- function(flnm = flnm.here, baylor_wells = 'none', adhoc_dilution_wells = 'none')
 { # Baylor wells : choose 1) none, 2) '.*' for all, 3) '[A-H]([1-9]$|10)' etc. for specific wells 
   
-  template_volume_dpcr <- 10 /22 * 20 # ul template volume per well of the 20 ul ddPCR reaction - for N1/N2
-  # template_volume_ddpcr <- tibble(Target = c('N1_multiplex', 'N2_multiplex', 'BCoV2'),
-  #                                 template_vol = c(10, 10, 4) /22 * 20) # ul template volume per well of the 20 ul ddPCR reaction for each target
+  template_volume_ddpcr <- tibble(Target = c('N1_multiplex', 'N2_multiplex', 'BCoV', 'pMMoV'),
+                                  template_vol = c(10, 10, 4, 4) /22 * 20) # ul template volume per well of the 20 ul ddPCR reaction for each target
   
-  template_volume_correction_BCoV <- 4 / 22 * 20 / template_volume_dpcr # BCoV reaction has only 4 ul instead of 10 ul in a 22 ul reaction
   RNA_dilution_factor_BCoV <- 50  # RNA dilution factor for diluted BCoV samples
-  total_correction_factor_BCoV <- RNA_dilution_factor_BCoV * template_volume_correction_BCoV # total correction factor to implement for BCoV samples 
   
   # Ad hoc - marking the samples from baylor (will append /baylor to target name)
   # Work in progress?
@@ -294,7 +291,11 @@ process_ddpcr <- function(flnm = flnm.here, baylor_wells = 'none', adhoc_dilutio
     right_join(plate_template, by = 'Well Position') %>%  # Incorporate samples names from the google sheet by matching well position
     mutate_at('Target', ~str_replace_all(., c('N1' = 'N1_multiplex' , 'N2' = 'N2_multiplex'))) %>% 
     filter(!is.na(Target)) %>% 
-    mutate('Copy #' = CopiesPer20uLWell/ template_volume_dpcr) %>% 
+    
+    # Adding different template volumes for each target for division
+    left_join(template_volume_ddpcr) %>% # join array of template volume - different for N1,N2 and BCOV2
+    mutate('Copy #' = CopiesPer20uLWell/ template_vol) %>%  
+    
     select(`Sample_name`, `Copy #`, Target, everything())
   
   
@@ -309,7 +310,7 @@ process_ddpcr <- function(flnm = flnm.here, baylor_wells = 'none', adhoc_dilutio
     mutate_at('assay_variable', as.character) %>% 
     mutate_at('biological_replicates', ~str_replace_na(., '')) %>% 
     
-    mutate(across(`Copy #`, ~ if_else(str_detect(Target, 'BCoV'), .x * total_correction_factor_BCoV, .x))) %>% # Correcting for template dilution in case of BCoV ddPCRs
+    mutate(across(`Copy #`, ~ if_else(str_detect(Target, 'BCoV'), .x * RNA_dilution_factor_BCoV, .x))) %>% # Correcting for template dilution in case of BCoV ddPCRs
     
     
     # Ad-hoc corrections for errors in making plate - sample dilutions etc.

--- a/processing_functions.R
+++ b/processing_functions.R
@@ -257,6 +257,8 @@ process_ddpcr <- function(flnm = flnm.here, baylor_wells = 'none', adhoc_dilutio
 { # Baylor wells : choose 1) none, 2) '.*' for all, 3) '[A-H]([1-9]$|10)' etc. for specific wells 
   
   template_volume_dpcr <- 10 /22 * 20 # ul template volume per well of the 20 ul ddPCR reaction - for N1/N2
+  # template_volume_ddpcr <- tibble(Target = c('N1_multiplex', 'N2_multiplex', 'BCoV2'),
+  #                                 template_vol = c(10, 10, 4) /22 * 20) # ul template volume per well of the 20 ul ddPCR reaction for each target
   
   template_volume_correction_BCoV <- 4 / 22 * 20 / template_volume_dpcr # BCoV reaction has only 4 ul instead of 10 ul in a 22 ul reaction
   RNA_dilution_factor_BCoV <- 50  # RNA dilution factor for diluted BCoV samples

--- a/weekly_comparisions.R
+++ b/weekly_comparisions.R
@@ -5,10 +5,10 @@ source('./general_functions.R') # Source the general_functions file
 source('./inputs_for_analysis.R') # Source the file with user inputs
 
 # sheets to read from "qPCR data to present + recoveries"" google sheet
-# read_these_sheets <- c('622 Rice', '629 Rice', '706 Rice', '713 Rice', '720 Rice', '727 Rice', '803 Rice', '810 Rice', '817 Rice', '824 Rice', '831 Rice', '907 Rice', '915 Rice') # sheet name(s) in the raw data file (qPCR data dump) - Separate by comma (,)
+read_these_sheets <- c('622 Rice', '629 Rice', '706 Rice', '713 Rice', '720 Rice', '727 Rice', '803 Rice', '810 Rice', '817 Rice', '824 Rice', '831 Rice', '907 Rice', '914 Rice', '928 Rice', '1005 Rice', '1012 Rice', '1019 Rice') # sheet name(s) in the raw data file (qPCR data dump) - Separate by comma (,)
 
-read_these_sheets <- c('810 Rice', '817 Rice', '824 Rice', '831 Rice', '907 Rice', '915 Rice') # sheet name(s) in the raw data file (qPCR data dump) - Separate by comma (,)
-title_name <- '810-915 Rice' # name of the filename for writing presentable data and plot title
+# read_these_sheets <- c('810 Rice', '817 Rice', '824 Rice', '831 Rice', '907 Rice', '915 Rice') # sheet name(s) in the raw data file (qPCR data dump) - Separate by comma (,)
+title_name <- 'Weekly till 1019' # name of the filename for writing presentable data and plot title
 
 # file for metadata - flow rate litres/day; population by WWTP area
 meta_file <- 'WWTP_All_Results' %>% str_c('../../../Covid Tracking Project/Rice and Baylor Combined Data/', ., '.csv')

--- a/weekly_comparisons.Rmd
+++ b/weekly_comparisons.Rmd
@@ -54,9 +54,11 @@ results_abs %>%
 ```{r n12violin}
 
 den.plt <- results_abs %>% filter(str_detect(Target, 'N1|N2')) %>% 
-  ggplot(aes(x = Week, y = `Copies/l WW`, colour = Target)) + geom_jitter(width = .1) + geom_violin()
+  ggplot(aes(x = Week, y = `Copies/l WW`, colour = Target, label = WWTP)) + geom_jitter(width = .1) + geom_violin()
 
 print(den.plt)
+
+ggplotly(den.plt, tooltip = 'label')
 ```
 
 ### Logscale N1-N2 Copies/L | Violin + Density plot


### PR DESCRIPTION
processing_functions: vectorized template volume assignment of ddpcr. Corrected mistake in BCoV correction values since dd.WW64 to dd.WW70
- only WWTP plotted in the html now
Many other changes
make_html_plots: Plotting only WWTP that match the biobots (+ manhole) '// separating all the controls away
- General functions: plot_mean_sd_jitter - has the defaul to plot only WWTP samples
- processing_functions: vectorized template volume assignment of ddpcr. Corrected mistake in BCoV correction values since dd.WW64 to dd.WW70
