### PR TITLE
Bcov dilution

### DIFF
--- a/1-processing_functions.R
+++ b/1-processing_functions.R
@@ -284,6 +284,8 @@ process_ddpcr <- function(flnm = flnm.here, baylor_wells = 'none', adhoc_dilutio
   bring_results <- fl %>% 
     select(-Sample) %>% # Remove sample, it will be loaded from plate template sheet
     rename(CopiesPer20uLWell = any_of('Copies/20µLWell')) %>% # rename the column name - if exported from Quantasoft analysis Pro
+    rename(Concentration = any_of('Conc(copies/µL)')) %>%  # rename the column name - if exported from Quantasoft analysis Pro
+    mutate(across(any_of('Concentration'), as.numeric)) %>%  # Remove the NO CALLS and make it numeric column  
     
     mutate_at('Well', ~ str_replace(., '(?<=[:alpha:])0(?=[:digit:])', '') ) %>% rename('Well Position' = Well) %>% 
     right_join(plate_template, by = 'Well Position') %>%  # Incorporate samples names from the google sheet by matching well position

--- a/1-processing_functions.R
+++ b/1-processing_functions.R
@@ -359,7 +359,7 @@ process_ddpcr <- function(flnm = flnm.here, baylor_wells = 'none', adhoc_dilutio
   vaccine_data.mean <- vaccine_data %>% ungroup() %>% 
     select(1:3, Target, `Copy #`, Run_ID) %>% group_by(across(-`Copy #`)) %>% 
     summarise(across(`Copy #`, list(Mean_qPCR = mean, SD_qPCR = sd), na.rm = T), .groups = 'keep') %>% 
-    mutate('[Stock conc.] copies/ul' = `Copy #_Mean_qPCR` * 50/20,
+    mutate('[Stock conc.] copies/ul' = `Copy #_Mean_qPCR` * if_else(str_detect(Vaccine_ID, 'S[:digit:]+'), 50/20, 1), # adding a RNA extraction conc. factor only if not boiled (Sbxx naming)
            'Estimated factor' = '',
            Comments = '',
            'Conc normalized to estimated factor' = '') %>% 

--- a/1-processing_functions.R
+++ b/1-processing_functions.R
@@ -258,6 +258,7 @@ process_ddpcr <- function(flnm = flnm.here, baylor_wells = 'none', adhoc_dilutio
                                   template_vol = c(10, 10, 4, 4) /22 * 20) # ul template volume per well of the 20 ul ddPCR reaction for each target
   
   RNA_dilution_factor_BCoV <- 50  # RNA dilution factor for diluted BCoV samples
+  Vaccine_additional_RNA_dilution_factor_BCoV <- 50  # In addition to the above: RNA dilution factor for BCoV vaccine samples - both extracted and boiled
   
   # Ad hoc - marking the samples from baylor (will append /baylor to target name)
   # Work in progress?
@@ -311,7 +312,8 @@ process_ddpcr <- function(flnm = flnm.here, baylor_wells = 'none', adhoc_dilutio
     mutate_at('biological_replicates', ~str_replace_na(., '')) %>% 
     
     mutate(across(`Copy #`, ~ if_else(str_detect(Target, 'BCoV'), .x * RNA_dilution_factor_BCoV, .x))) %>% # Correcting for template dilution in case of BCoV ddPCRs
-    
+    mutate_cond(str_detect(Sample_name, 'Vaccine') & str_detect(Target, 'BCoV'), 
+                across(`Copy #`, ~ .x * Vaccine_additional_RNA_dilution_factor_BCoV)) %>%  # Correcting for BCoV Vaccine with a higher dilution
     
     # Ad-hoc corrections for errors in making plate - sample dilutions etc.
     mutate_cond(str_detect(`Well Position`, adhoc_dilution_wells), # Regex of wells to manipulate

--- a/1-processing_functions.R
+++ b/1-processing_functions.R
@@ -311,7 +311,12 @@ process_ddpcr <- function(flnm = flnm.here, baylor_wells = 'none', adhoc_dilutio
     mutate_at('assay_variable', as.character) %>% 
     mutate_at('biological_replicates', ~str_replace_na(., '')) %>% 
     
-    mutate(across(`Copy #`, ~ if_else(str_detect(Target, 'BCoV'), .x * RNA_dilution_factor_BCoV, .x))) %>% # Correcting for template dilution in case of BCoV ddPCRs
+    mutate(raw_copy_number_per_ul_rna = `Copy #`) %>%  # taking a backup of the copy number column before doing calculations for dilution factors
+    mutate(across(`Copy #`, 
+                  ~ if_else(str_detect(Target, 'BCoV') & !str_detect(Sample_name, 'NTC'), 
+                            .x * RNA_dilution_factor_BCoV, 
+                            .x))
+           ) %>% # Correcting for template dilution in case of BCoV ddPCRs (excluding NTC wells)
     mutate_cond(str_detect(Sample_name, 'Vaccine') & str_detect(Target, 'BCoV'), 
                 across(`Copy #`, ~ .x * Vaccine_additional_RNA_dilution_factor_BCoV)) %>%  # Correcting for BCoV Vaccine with a higher dilution
     

--- a/2-calculations_multiple_runs.R
+++ b/2-calculations_multiple_runs.R
@@ -196,6 +196,25 @@ processed_quant_data <- bind_rows(vol_R, vol_B) %>%
 # Adding a dummy CT column (if only ddPCR data is being loaded; which lacks the CT column) - for compatibility with qPCR code
 if(processed_quant_data %>%  {!'CT' %in% colnames(.)}) processed_quant_data$CT = NA
 
+# Vaccine ID duplication value check - Brings user attention to duplicate values in the Vaccine_summary in data dump
+processed_quant_data$Vaccine_ID %>% 
+  unique() %>%  # find all the Vaccine IDs in use for the current week data
+  paste(collapse = '|') %>% # make a regular expression (regex) combining them
+  
+  {filter(spike_list, str_detect(Vaccine_ID, .))} %>% 
+  unique %>%  # filter the list of vaccine data with these IDs (from data dump) that are unique
+  {if(nrow (.) > 1) {
+    duplicate_vaccine_values <- . 
+    view(duplicate_vaccine_values)
+    stop("Duplicate vaccine IDs found in the data dump, 
+         please check the table: *duplicate_vaccine_values* for more information")
+  }
+    if(.$spike_virus_conc == 0){
+      zero_vaccine_values <- . 
+      view(zero_vaccine_values)
+      stop("Zeros found in vaccine quants in the data dump, please fix") 
+    }
+  }
 
 # Data output ----------------------------------------------------------------------
 

--- a/2-calculations_multiple_runs.R
+++ b/2-calculations_multiple_runs.R
@@ -42,8 +42,8 @@ raw_quant_data <- bind_rows(list_raw_quant_data) %>%
   mutate_at('assay_variable', as.character) %>% 
   mutate_at('biological_replicates', ~str_replace_na(., '')) %>% 
   mutate_at('Tube ID', ~str_remove(., "\\.")) %>% 
-  unite('Label_tube', c('Sample_name', 'Tube ID'), sep = "", remove = F) # make a unique column for matching volumes 
-
+  unite('Label_tube', c('Sample_name', 'Tube ID'), sep = "", remove = F) %>%  # make a unique column for matching volumes 
+  mutate(across(Label_tube, ~str_remove(., ' ') )) # remove spaces from the Sample_name (Started with 1123 Pavan with 1123 69S names)
 
 # Load metadata ----------------------------------------------------------------------
 

--- a/2-calculations_multiple_runs.R
+++ b/2-calculations_multiple_runs.R
@@ -325,13 +325,13 @@ long_processed_minimal$summ.dat %<>% separate(Measurement, into = c('Measurement
   pivot_wider(names_from = val, values_from = value) # Seperate mean and variance and group by variable of measurement
 
 # Adding back the underscore in columns (ex: Percentage_recovery_BCoV)
-# processed_minimal %>% map( ~ rename(.x, Percentage_recovery_BCoV = 'Percentage.recovery.BCoV'))
-# long_processed_minimal %<>% map(
-#   ~ mutate(.x, across (Measurement,
-#                        ~ str_replace(.x, 'Percentage.recovery.BCoV', 'Percentage_recovery_BCoV')
-#   )
-#   )
-# )
+processed_minimal %<>% map( ~ rename(.x, Percentage_recovery_BCoV = contains('Percentage.recovery.BCoV')))
+long_processed_minimal %<>% map(
+  ~ mutate(.x, across (Measurement,
+                       ~ str_replace(.x, 'Percentage.recovery.BCoV', 'Percentage_recovery_BCoV')
+  )
+  )
+)
 
 
 # Plotting into html -----------------------------------------------------------------------

--- a/make_html_plots.Rmd
+++ b/make_html_plots.Rmd
@@ -25,7 +25,7 @@ Quantifying CoV2-N1,N2 (multiplexed) and BCoV surrogate spiked into wastewater s
 ```{r scripts, fig.width = 12}
 
 # Make a string to filter out all regular WWTP and manhole samples to plot separately
-wwtp_manhole_names <- all_WWTP_names %>% str_c(collapse = '|') %>% str_c(manhole_samples, sep = '|')
+wwtp_manhole_names <- all_WWTP_names %>% str_c(collapse = '|') %>% str_c(manhole_sample_symbols, sep = '|')
 
 # plot individual biological replicates (for quality control)
 # map2(list_rawqpcr, read_these_sheets, ~(plot_biological_replicates(.x, title_text = .y)))


### PR DESCRIPTION
Accounting for differential dilution of the BCoV vaccine (excluding NTCs) and a few error checks

- Introducing error check for duplicate or zero vaccine values taken from the vaccine_summary in data dump
- 2-calculations : fixed error with perc_rec_BCoV name correction in processed_minimal list. (Fix #35)
- 1-process.funs: changing column name of concentration and removing NO CALLs by converting to numeric
- 1-processing_funs : Accounting for higher dilution of BCoV vaccine (2,500 fold = 50 x 50).
- make_html_plots : accounting for changed name of manhole_samples to manhole_sample_symbols
- 2-calculations : removed spaces within Sample_name or Tube_ID to match with the sample registry which has spaces removed by the code
- 1-processing: Excluding NTCs from being scaled for BCoV targets - since NTC are technically not diluted
- 1-processing : post scaling 50/20 times for rna extract, excluding boiled vaccines by Sbxx signature (or the absence of Sxx signature)

